### PR TITLE
Fixes :

### DIFF
--- a/Deploy/DeployUnified.ps1
+++ b/Deploy/DeployUnified.ps1
@@ -15,14 +15,19 @@ az account set --subscription $subscription
 Push-Location $($MyInvocation.InvocationName | Split-Path)
 Push-Location Scripts
 
-& ./Deploy-ARMs.ps1 -resourceGroup $resourceGroup -location $location -resourcePrefixName $resourcePrefixName
+& ./Deploy-ARM.ps1 -resourceGroup $resourceGroup -location $location -resourcePrefixName $resourcePrefixName
 
 $storageName = $(az resource list --resource-group $resourceGroup --resource-type Microsoft.Storage/storageAccounts -o json | ConvertFrom-Json)[0].name
 $containerName = "$resourcePrefixName-trainmodel"
 $containerNameProducts = "$resourcePrefixName-products"
 $appFunctionName = $(az resource list --resource-group $resourceGroup --resource-type Microsoft.Web/sites -o json | ConvertFrom-Json)[0].name
 
-& ./Deploy-Publish-Content.ps1 -resourceGroup $resourceGroup -storageName $storageName -containerName $containerName -containerNameProducts $containerNameProducts -appFunctionName $appFunctionName
+echo "Storage Name :  $storageName"
+echo "Container Name :  $containerName"
+echo "Container Name Products:  $containerNameProducts"
+echo "App Function Name:  $appFunctionName"
+
+& ./Deploy-Publish-Content.ps1 -resourceGroup $resourceGroup -storageName $storageName -containerName $containerName -appFunctionName $appFunctionName
 
 Pop-Location
 Pop-Location

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ You can deploy the scenario using one script under `/Deploy` folder.
 Running the following command you can deploy starting with the infrastructure and ending with deploying the images on the storage:
 
 ```
-.\Deploy-Unified.ps1 -resourceGroup <resource-group-name> -location <location> -clientId <service-principal-id> -password <service-principal-password> -subscription <subscription-id> -prefixName <prefix-name>
+.\DeployUnified.ps1 -resourceGroup <resource-group-name> -location <location> - -subscription <subscription-id> -resourcePrefixName <resource-prefix-name>
 ```
 
 - `resourceGroup`: The name of your resource group where all infrastructure will be created `Required`
 - `location`: Select where you want to create your resource group. (i.e., East US) `Required`
 - `subscription`: Id of your subscription where you are going to deploy your resource group `Required`
-- `prefixName`: The name to refer the resources to be deployed. It will be composed with the following format: *prefixname-resourcetype-resourceGroupNameEncoded* (i.e., if you enter as a prefix name: tailwind, Azure Function resource name will become: *tailwindfunction12875156*). `Required`
+- `resourcePrefixNameName`: The name to refer the resources to be deployed. It will be composed with the following format: *prefixname-resourcetype-resourceGroupNameEncoded* (i.e., if you enter as a prefix name: tailwind, Azure Function resource name will become: *tailwindfunction12875156*). `Required`
 
 The resources that will be deployed are:
 - Azure Function.


### PR DESCRIPTION
README file fixes:
Since the name of Deploy-Unified.ps1 is renamed as "DeployUnified.ps1", we should update the 48th line accordingly.
As we do not need clientId and password parameters according to the script of DeployUnified.ps1 file, we should remove those parameters from read me file, otherwise it throws an error.
Again as we need resourcePrefixName parameter instead of prefixName parameter, we should update the 48th & 54th lines accordingly.

Deploy/DeployUnified.ps1 file fixes:
Since the Deploy-ARMs.ps1 file is renamed as Deploy-ARM.ps1, the 18th line of DeployUnified.ps1 file should be updated accordingly.
And, as we need to know the "containerNameProducts" parameter's value during the Deploy-Publish-Content.ps1 file execution, I just added an echo line to let the developers see the value.