### PR TITLE
Update FormRecognizer SDK to track2

### DIFF
--- a/Source/TailwindTraders.ShippingManagement/Scan.cs
+++ b/Source/TailwindTraders.ShippingManagement/Scan.cs
@@ -45,8 +45,7 @@ namespace TailwindTraders.ShippingManagement
 
                 using (FileStream fStream = new FileStream(tempFilePath, FileMode.Open))
                 {
-                    var fileMimeType = _svcRequest.GetMimeTypeFromFilePath(tempFilePath);
-                    var analyzeResult = await _svcAnalisys.AnalyzeAsync(fileMimeType, fStream);
+                    var analyzeResult = await _svcAnalisys.AnalyzeAsync(fStream);
                     if (analyzeResult != null)
                     {
                         model = _svcResponse.Parse(analyzeResult);

--- a/Source/TailwindTraders.ShippingManagement/Services/AnalysisService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/AnalysisService.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-
-using Microsoft.Azure.CognitiveServices.FormRecognizer;
-using Microsoft.Azure.CognitiveServices.FormRecognizer.Models;
+using Azure;
+using Azure.AI.FormRecognizer;
+using Azure.AI.FormRecognizer.Models;
+using Azure.AI.FormRecognizer.Training;
 using Microsoft.Extensions.Options;
 
 using TailwindTraders.ShippingManagement.Models;
@@ -15,62 +17,56 @@ namespace TailwindTraders.ShippingManagement.Services
     public class AnalysisService : IAnalysisService
     {
         private readonly Settings _settings;
-        private readonly IFormRecognizerClient _formClient;
+        private readonly FormTrainingClient _formTrainedClient;
         private const int C_MinNumTrainning = 3;
 
         public AnalysisService(IOptions<Settings> settings)
         {
             _settings = settings.Value;
-            _formClient = CreateFormRecognizerClient();
+            _formTrainedClient = CreateFormTrainingClient();
         }
 
-        private IFormRecognizerClient CreateFormRecognizerClient()
+        private FormTrainingClient CreateFormTrainingClient()
         {
-            IFormRecognizerClient formClient = new FormRecognizerClient(
-                new ApiKeyServiceClientCredentials(_settings.FormRecognizedSubscriptionKey))
-            {
-                Endpoint = _settings.FormRecognizedEndPoint
-            };
-
-            return formClient;
+            FormTrainingClient formTrainedClient = new FormTrainingClient(new Uri(_settings.FormRecognizedEndPoint), new AzureKeyCredential(_settings.FormRecognizedSubscriptionKey));
+            return formTrainedClient;
         }
-
-        private async Task<Guid> TrainModelAsync()
+        private async Task<string> TrainModelAsync()
         {
             if (Uri.IsWellFormedUriString(_settings.FormRecognizedTrainningDataUrl, UriKind.Absolute))
             {
                 try
                 {
-                    TrainResult result = await _formClient.TrainCustomModelAsync(new TrainRequest(_settings.FormRecognizedTrainningDataUrl));
-                    ModelResult model = await _formClient.GetCustomModelAsync(result.ModelId);
+                    CustomFormModel result = await _formTrainedClient.StartTrainingAsync(new Uri(_settings.FormRecognizedTrainningDataUrl), useTrainingLabels: false).WaitForCompletionAsync();
+
+                    CustomFormModel model = await _formTrainedClient.GetCustomModelAsync(result.ModelId);
 
                     return result.ModelId;
                 }
                 catch (Exception)
                 {
-                    return Guid.Empty;
+                    return null;
                 }
             }
-            return Guid.Empty;
+            return null;
         }
 
-        private async Task<Guid> GetLastModelIDAsync()
+        private async Task<string> GetLastModelIDAsync()
         {
             try
             {
-                ModelsResult models = await _formClient.GetCustomModelsAsync();
-
-                if (models == null || (models != null && models.ModelsProperty.Count < C_MinNumTrainning)) 
+                IAsyncEnumerator<CustomFormModelInfo> models =  _formTrainedClient.GetCustomModelsAsync().GetAsyncEnumerator();
+                if (models.Current == null || !(await models.MoveNextAsync() && await models.MoveNextAsync())) 
                 {
                     for (var i = 0; i < C_MinNumTrainning; i++)
                     {
                         await TrainModelAsync();
                     }
 
-                    models = await _formClient.GetCustomModelsAsync();
+                    models = _formTrainedClient.GetCustomModelsAsync().GetAsyncEnumerator();
                 }
 
-                return models.ModelsProperty.First().ModelId;
+                return models.Current.ModelId;
 
             }
             catch (Exception ex)
@@ -79,7 +75,7 @@ namespace TailwindTraders.ShippingManagement.Services
             }
         }
 
-        public async Task<AnalyzeResult> AnalyzeAsync(string fileMimeType, Stream fileStream)
+        public async Task<RecognizedFormCollection> AnalyzeAsync(string fileMimeType, Stream fileStream)
         {
            
             if (fileStream == null || fileStream.Length == 0) 
@@ -89,12 +85,8 @@ namespace TailwindTraders.ShippingManagement.Services
 
             try
             {
-                Guid modelId = await GetLastModelIDAsync();
-                return (modelId != Guid.Empty) ? await _formClient.AnalyzeWithCustomModelAsync(modelId, fileStream, fileMimeType) : null;
-            }
-            catch (ErrorResponseException exr)
-            {
-                throw exr;
+                string modelId = await GetLastModelIDAsync();
+                return (modelId != null) ? await _formTrainedClient.GetFormRecognizerClient().StartRecognizeCustomFormsAsync(modelId, fileStream).WaitForCompletionAsync() : null;
             }
             catch (Exception ex)
             {

--- a/Source/TailwindTraders.ShippingManagement/Services/AnalysisService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/AnalysisService.cs
@@ -38,9 +38,6 @@ namespace TailwindTraders.ShippingManagement.Services
                 try
                 {
                     CustomFormModel result = await _formTrainingClient.StartTrainingAsync(new Uri(_settings.FormRecognizedTrainningDataUrl), useTrainingLabels: false).WaitForCompletionAsync();
-
-                    await _formTrainingClient.GetCustomModelAsync(result.ModelId);
-
                     return result.ModelId;
                 }
                 catch (Exception)

--- a/Source/TailwindTraders.ShippingManagement/Services/Contracts/IFormReconigzedService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/Contracts/IFormReconigzedService.cs
@@ -1,12 +1,12 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 
-using Microsoft.Azure.CognitiveServices.FormRecognizer.Models;
+using Azure.AI.FormRecognizer.Models;
 
 namespace TailwindTraders.ShippingManagement.Services.Contracts
 {
     public interface IAnalysisService
     {
-        Task<AnalyzeResult> AnalyzeAsync(string fileContentType, Stream fileStream);
+        Task<RecognizedFormCollection> AnalyzeAsync(string fileContentType, Stream fileStream);
     }
 }

--- a/Source/TailwindTraders.ShippingManagement/Services/Contracts/IFormReconigzedService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/Contracts/IFormReconigzedService.cs
@@ -7,6 +7,6 @@ namespace TailwindTraders.ShippingManagement.Services.Contracts
 {
     public interface IAnalysisService
     {
-        Task<RecognizedFormCollection> AnalyzeAsync(string fileContentType, Stream fileStream);
+        Task<RecognizedFormCollection> AnalyzeAsync(Stream fileStream);
     }
 }

--- a/Source/TailwindTraders.ShippingManagement/Services/Contracts/IResponseService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/Contracts/IResponseService.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.Azure.CognitiveServices.FormRecognizer.Models;
+﻿using Azure.AI.FormRecognizer.Models;
 using TailwindTraders.ShippingManagement.Models;
 
 namespace TailwindTraders.ShippingManagement.Services.Contracts
 {
     public interface IResponseService
     {
-        PackagingSlip Parse(AnalyzeResult result);
+        PackagingSlip Parse(RecognizedFormCollection result);
 
         bool ChecksLocation(string requestLocation);
     }

--- a/Source/TailwindTraders.ShippingManagement/Services/RequestService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/RequestService.cs
@@ -21,8 +21,7 @@ namespace TailwindTraders.ShippingManagement.Services
         {
             using (StreamReader reader = new StreamReader(streamBody))
             {
-                Request = JsonConvert.DeserializeObject<Request>(reader.ReadToEnd());
-                
+                Request = JsonConvert.DeserializeObject<Request>(reader.ReadToEndAsync().Result);                
                 if (!string.IsNullOrEmpty(Request.Source))
                 {
                     string parseFile = ParseFile(Request.Source);

--- a/Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
@@ -78,7 +78,6 @@ namespace TailwindTraders.ShippingManagement.Services
         {
             foreach (var header in _wrap.Keys)
             {
-                
                 if (page.Fields.Any(c => c.Value.LabelData.Text == header.Key))
                 {
                     var kv = page.Fields.Where(c => c.Value.LabelData.Text == header.Key).First();

--- a/Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
@@ -118,7 +118,7 @@ namespace TailwindTraders.ShippingManagement.Services
                         ItemProperty itemProp = new ItemProperty()
                         {
                             Value = c.Text,
-                            Accuracy = String.IsNullOrEmpty(c.Confidence.ToString()) ? (double)c.Confidence : 0
+                            Accuracy = String.IsNullOrEmpty(c.Confidence.ToString()) ? 0 : (double)c.Confidence
                         };
 
                         var header = _wrap.Tables[numTable].Headers.Where(h => h.Key == c.Text).FirstOrDefault();

--- a/Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
@@ -152,7 +152,7 @@ namespace TailwindTraders.ShippingManagement.Services
                 {
                     ItemProperty prop = item.GetProperty<ItemProperty>(header.Property);
 
-                    if (!item.HasPotentialErrors && !string.IsNullOrEmpty(prop.Value))
+                    if (!item.HasPotentialErrors && !string.IsNullOrEmpty(prop?.Value))
                     {
                         switch (header.Type)
                         {

--- a/Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
+++ b/Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
@@ -78,9 +78,10 @@ namespace TailwindTraders.ShippingManagement.Services
         {
             foreach (var header in _wrap.Keys)
             {
-                if (page.Fields.Any(c => c.Key[header.KeyPos].ToString() == header.Key))
+                
+                if (page.Fields.Any(c => c.Value.LabelData.Text == header.Key))
                 {
-                    var kv = page.Fields.Where(c => c.Key[header.KeyPos].ToString() == header.Key).First();
+                    var kv = page.Fields.Where(c => c.Value.LabelData.Text == header.Key).First();
 
                     if (kv.Value != null)
                     {

--- a/Source/TailwindTraders.ShippingManagement/TailwindTraders.ShippingManagement.csproj
+++ b/Source/TailwindTraders.ShippingManagement/TailwindTraders.ShippingManagement.csproj
@@ -4,8 +4,8 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.AI.FormRecognizer" Version="3.0.0" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.FormRecognizer" Version="0.8.0-preview" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.30-beta2" />
   </ItemGroup>


### PR DESCRIPTION
Form recognizer track1 package "Microsoft.Azure.CognitiveServices.FormRecognizer"  is not supported for azure portal now. Because the api version is so old that now portal abandon it.
I'm not sure my change to process the result of formrecognizer's analysis  logic  whether is the same as track1. Because I can't run the project with track1 package.

Update file list:
1. ./Source/TailwindTraders.ShippingManagement/Services/AnalysisService.cs
2. ./Source/TailwindTraders.ShippingManagement/Services/Contracts/IFormReconigzedService.cs
3. ./Source/TailwindTraders.ShippingManagement/Services/Contracts/IResponseService.cs
4. ./Source/TailwindTraders.ShippingManagement/Services/ResponseService.cs
5. ./Source/TailwindTraders.ShippingManagement/TailwindTraders.ShippingManagement.csproj

@jongio for notification.